### PR TITLE
Feature/commitid in monospace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /.project
 /.zfproject.xml
 /.gitignore
+/.idea
+*.iml

--- a/frontend/app/view/BundleGrid.js
+++ b/frontend/app/view/BundleGrid.js
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2013 pingworks - Alexander Birk und Christoph Lukas
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -10,7 +10,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,9 +20,9 @@ Ext.define("Dash.view.BundleGrid", {
     requires: 'Ext.grid.column.Action',
     store: 'Bundles',
     width: '100%',
-    
+
     id: 'BundleGrid',
-    
+
     stageStatusIconRenderer: function(value, metadata, record, rowIndex, colIndex, store, view) {
         // work around extjs bug: colIndex is wrong when some cols are hidden
     	var offset = 0;
@@ -40,33 +40,33 @@ Ext.define("Dash.view.BundleGrid", {
         this.columns[colIndex + offset].items[0].icon = iconUrl;
         this.columns[colIndex + offset].items[0].iconCls = iconCls;
     },
-    
+
     deploymentActionRenderer: function(value, metadata, record, rowIndex, colIndex, store, view) {
         var ctrl = Dash.app.getController('Deployment');
-        this.columns[this.colIndexDeployment].items[0].iconCls = 
+        this.columns[this.colIndexDeployment].items[0].iconCls =
             ctrl.deploymentAllowed(record) ? '' : 'x-item-disabled';
     },
-    
+
     triggerJenkinsJobActionRenderer: function(value, metadata, record, rowIndex, colIndex, store, view) {
         var ctrl = Dash.app.getController('TriggerJenkinsJob');
-        this.columns[this.colIndexTriggerJenkinsJob].items[0].iconCls = 
+        this.columns[this.colIndexTriggerJenkinsJob].items[0].iconCls =
             ctrl.triggerJenkinsJobAllowed(record) ? '' : 'x-item-disabled';
     },
-    
+
     createChangeTooltip: function(target, bundle) {
         return Ext.create('Dash.view.ChangeToolTip', {
             id: 'TTC-' + bundle.get('id').replace(/\./g, '-'),
             target: target
         });
     },
-    
+
     createJobResultTooltip: function(target, bundle, stage) {
         return Ext.create('Dash.view.JobResultToolTip', {
             id: 'TTJR-' + bundle.get('id').replace(/\./g, '-') + '-' + stage,
             target: target
         });
     },
-    
+
     initComponent: function() {
         var that = this;
         this.columns = [{
@@ -84,6 +84,7 @@ Ext.define("Dash.view.BundleGrid", {
         }, {
             text: Dash.config.bundlegrid.label.revision,
             dataIndex: 'revision',
+            tdCls: 'bundle-revision-column',
             renderer: function(value, metadata, record, rowIndex, colIndex, store, view) {
                 return ( Dash.config.bundlegrid.vcslink && Dash.config.bundlegrid.vcslink != ''  && record.get('revision') != 'Unavailable')
                     ? Ext.String.format(Dash.config.bundlegrid.vcslink, record.get('repository'), record.get('revision'))
@@ -122,9 +123,9 @@ Ext.define("Dash.view.BundleGrid", {
                 handler: function(gridview, rowIndex, colIndex, item, event, record) {
                     that.fireEvent('hideAllTooltips');
                     that.fireEvent(
-                        'loadJobResult', 
-                        record, 
-                        1, 
+                        'loadJobResult',
+                        record,
+                        1,
                         that.createJobResultTooltip(event.target, record, 1)
                     );
                 }
@@ -143,9 +144,9 @@ Ext.define("Dash.view.BundleGrid", {
                 handler: function(gridview, rowIndex, colIndex, item, event, record) {
                     that.fireEvent('hideAllTooltips');
                     that.fireEvent(
-                        'loadJobResult', 
-                        record, 
-                        2, 
+                        'loadJobResult',
+                        record,
+                        2,
                         that.createJobResultTooltip(event.target, record, 2)
                     );
                 }
@@ -164,9 +165,9 @@ Ext.define("Dash.view.BundleGrid", {
                 handler: function(gridview, rowIndex, colIndex, item, event, record) {
                     that.fireEvent('hideAllTooltips');
                     that.fireEvent(
-                        'loadJobResult', 
-                        record, 
-                        3, 
+                        'loadJobResult',
+                        record,
+                        3,
                         that.createJobResultTooltip(event.target, record, 3)
                     );
                 }
@@ -187,8 +188,8 @@ Ext.define("Dash.view.BundleGrid", {
                 handler: function(gridview, rowIndex, colIndex, item, event, record) {
                     that.fireEvent('hideAllTooltips');
                     that.fireEvent(
-                        'loadChanges', 
-                        record, 
+                        'loadChanges',
+                        record,
                         that.createChangeTooltip(event.target, record)
                     );
                 }
@@ -230,15 +231,15 @@ Ext.define("Dash.view.BundleGrid", {
             renderer: this.triggerJenkinsJobActionRenderer,
             scope: this
         }];
-        
+
         Ext.Array.forEach(this.columns, function(column, index) {
             if (column.id == 'ColumnDeployment')
-               this.colIndexDeployment = index; 
+               this.colIndexDeployment = index;
         }, this);
 
         Ext.Array.forEach(this.columns, function(column, index) {
             if (column.id == 'ColumnTriggerJenkinsJob')
-               this.colIndexTriggerJenkinsJob = index; 
+               this.colIndexTriggerJenkinsJob = index;
         }, this);
 
         this.callParent(arguments);

--- a/frontend/dash.css
+++ b/frontend/dash.css
@@ -1,0 +1,3 @@
+.x-grid-row .x-grid-cell.bundle-revision-column {
+    font-family: monospace;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,7 @@
     <!-- <x-compile> -->
         <!-- <x-bootstrap> -->
             <link rel="stylesheet" href="bootstrap.css">
+            <link rel="stylesheet" href="dash.css">
             <script src="ext/ext-dev.js"></script>
             <script src="bootstrap.js"></script>
         <!-- </x-bootstrap> -->


### PR DESCRIPTION
Anzeige der Revisionsspalte um Übersichtlichkeit bei Git-Commit-IDs zu gewährleisten
