### PR TITLE
hide ALL folder (with all bundle links) in dashbaord

### DIFF
--- a/backend/application/models/BranchPeer.php
+++ b/backend/application/models/BranchPeer.php
@@ -27,6 +27,10 @@ class Application_Model_BranchPeer
 			if ( ! $directory->isDot() && $directory->isDir())
 			{
 				$basename = $directory->getBasename();
+				/* Skip ALL folder, for internal use only */
+				if ($basename == "ALL") {
+					continue;
+				}
 		 		if ($basename === Zend_Registry::get("defaultbranch"))
 		 		{
 		 			$default = $basename;


### PR DESCRIPTION
hide special folder named ALL, which contains in our case symlinks to bundles for all branches
