### PR TITLE
Reservierung ohne Deployment zulassen

### DIFF
--- a/frontend/app/view/EnvironmentGrid.js
+++ b/frontend/app/view/EnvironmentGrid.js
@@ -83,9 +83,6 @@ Ext.define("Dash.view.EnvironmentGrid", {
                 width: 60,
                 items: [{
                     icon: Dash.config.bundlegrid.icon.lockExtension,
-                    isDisabled: function (gridview, rowIndex, colIndex, item, record) {
-                        return !record.get('locked');
-                    },
                     handler: function(gridview, rowIndex, colIndex, item, event, record) {
                         that.fireEvent('showLockExtensionWindow', record);
                     }


### PR DESCRIPTION
Hallo,
Die Möglichkeit Reservierungen zu verlängern, war nicht ganz das, was wir uns gedacht haben.
Ich habe es noch ergänzt, sodass man jederzeit eine Maschine auch ohne Deployment über die Umgebungsübersicht reservieren kann.
