### PR TITLE
Fail if more than one bundle is found

### DIFF
--- a/scripts/shared/repo/localfs.sh
+++ b/scripts/shared/repo/localfs.sh
@@ -13,6 +13,9 @@ function getBundleFolder() {
   if [ -z "${BUNDLE_FOLDER}" ]; then
     echo "Bundle not found: $BUNDLE"
     exit 1
+  elif [ $(echo "${BUNDLE_FOLDER}" | wc -l) -ne 1 ]; then
+    echo "Expected 1 Bundle, but got: $BUNDLE_FOLDER"
+    exit 1
   fi
 }
 


### PR DESCRIPTION
If you throw away jenkins without re-provisioning dash, you get duplicate BUNDLE identifiers, and all hell breaks loose:
* find finds more than one directory
* the variable $BUNDLE_FOLDER contains one or more newlines
* as it is used in a quoted way later in addMetadata, bash interprets this as two commands instead of one
** the first one does not have enough arguments
** the second one is not executable, as it is a bundle folder

-> It is preferable to fail earlier.

I don't know enough about the setup if there is a smarter choice, i.e. if more than one bundle is found, use the "right" one - maybe by using the one that was created later?